### PR TITLE
Add synchronization to XText calls in XillProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ## Fix
 
-* Add Mongo.find "batchSize" option documentation [XP_5]
+* Add `Mongo.find` `batchSize` option documentation 
+* Deadlock when compiling multiple robots at the same time
 
 ## [3.6.9] - 2018-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ All notable changes to this project will be documented in this file.
 
 ## Fix
 
-* Add `Mongo.find` `batchSize` option documentation 
-* Deadlock when compiling multiple robots at the same time
+* Add `Mongo.find` `batchSize` option documentation [#5]
+* Deadlock when compiling multiple robots at the same time [#8]
 
 ## [3.6.9] - 2018-04-19
 
 ### Add
 
-* Add binary support for the Mongo plugin 
+* Add binary support for the Mongo plugin [#1]
 
 ## [3.6.8] - 2018-02-27
 

--- a/xill-processor/src/main/java/nl/xillio/xill/XillProcessor.java
+++ b/xill-processor/src/main/java/nl/xillio/xill/XillProcessor.java
@@ -254,9 +254,9 @@ public class XillProcessor implements nl.xillio.xill.api.XillProcessor {
 
     private List<Issue> doValidate(final Resource resource, final RobotID robotID) {
         // Validate
-        List<org.eclipse.xtext.validation.Issue> rawIssues
+        List<org.eclipse.xtext.validation.Issue> rawIssues;
         synchronized (XTEXT_LOCK) {
-            rawIssues = validator.validate(resource, CheckMode.ALL, CancelIndicator.NullImpl)
+            rawIssues = validator.validate(resource, CheckMode.ALL, CancelIndicator.NullImpl);
         }
 
         List<Issue> issues = rawIssues.stream().map(issue -> {


### PR DESCRIPTION
Concerning tests: The XillProcessor class was not designed to be unit-testable, therefore it's hard to write a unit test for the locking behaviour without either significantly refatoring for testability or making some questionable alterations in the name of testability. Writing a parallel integration test requires a lot of setup and coding, which has already been done in the XDE testing code. Therefore we'll test the effectiveness of the locking in XDE, instead of this repository.

Fixes #8 