### PR TITLE
Update saxon version and workaround unix path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [3.7.0] - unreleased
 
+### Fix
+
+* XML Plugins's XSD validator fails on Linux [#1933]
+
 ## [3.6.9] - 2018-04-19
 
 ### Add

--- a/plugin-xml/src/main/java/nl/xillio/xill/plugins/xml/services/XsdServiceImpl.java
+++ b/plugin-xml/src/main/java/nl/xillio/xill/plugins/xml/services/XsdServiceImpl.java
@@ -68,7 +68,7 @@ public class XsdServiceImpl implements XsdService, ErrorHandler {
     public boolean xsdCheck(final Path xmlFile, final Path xsdFile, final Logger logger) {
         messages.clear();
 
-        dbf.setAttribute(JAXP_SCHEMA_SOURCE, xsdFile);
+        dbf.setAttribute(JAXP_SCHEMA_SOURCE, xsdFile.toAbsolutePath().toString());
         try (InputStream stream = Files.newInputStream(xmlFile, StandardOpenOption.READ)) {
 
             DocumentBuilder db = dbf.newDocumentBuilder();

--- a/xill-processor/src/test/resources/testresources/xml/xpathTest.xml
+++ b/xill-processor/src/test/resources/testresources/xml/xpathTest.xml
@@ -27,7 +27,8 @@
             </s:parent>
             <s:file>
                 <s:rawExtension>csv</s:rawExtension>
-                <s:path>C:\\projects\\All_Connector_Projects\\TESTSET_CONNECTORS\\csv\\20090803_Mapping_owinsp.csv</s:path>
+                <s:path>C:\\projects\\All_Connector_Projects\\TESTSET_CONNECTORS\\csv\\20090803_Mapping_owinsp.csv
+                </s:path>
                 <s:extension>csv</s:extension>
                 <s:size type="NumberLong">1189928</s:size>
                 <s:name>20090803_Mapping_owinsp.csv</s:name>
@@ -66,7 +67,8 @@
             </t:parent>
             <t:file>
                 <t:rawExtension>csv</t:rawExtension>
-                <t:path>C:\\projects\\All_Connector_Projects\\TESTSET_CONNECTORS\\csv\\20090803_Mapping_owinsp.csv</t:path>
+                <t:path>C:\\projects\\All_Connector_Projects\\TESTSET_CONNECTORS\\csv\\20090803_Mapping_owinsp.csv
+                </t:path>
                 <t:extension>csv</t:extension>
                 <t:size type="NumberLong">1189928</t:size>
                 <t:name>20090803_Mapping_owinsp.csv</t:name>

--- a/xill-processor/src/test/resources/testresources/xml/xsdValidation.xml
+++ b/xill-processor/src/test/resources/testresources/xml/xsdValidation.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<shiporder orderid="889923">
+  <orderperson>John Smith</orderperson>
+  <shipto>
+    <name>Ola Nordmann</name>
+    <address>Langgt 23</address>
+    <city>4000 Stavanger</city>
+    <country>Norway</country>
+  </shipto>
+  <item>
+    <title>Empire Burlesque</title>
+    <note>Special Edition</note>
+    <quantity>1</quantity>
+    <price>10.90</price>
+  </item>
+  <item>
+    <title>Hide your heart</title>
+    <quantity>1</quantity>
+    <price>9.90</price>
+  </item>
+</shiporder>

--- a/xill-processor/src/test/resources/testresources/xml/xsdValidation.xml
+++ b/xill-processor/src/test/resources/testresources/xml/xsdValidation.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <shiporder orderid="889923">
-  <orderperson>John Smith</orderperson>
-  <shipto>
-    <name>Ola Nordmann</name>
-    <address>Langgt 23</address>
-    <city>4000 Stavanger</city>
-    <country>Norway</country>
-  </shipto>
-  <item>
-    <title>Empire Burlesque</title>
-    <note>Special Edition</note>
-    <quantity>1</quantity>
-    <price>10.90</price>
-  </item>
-  <item>
-    <title>Hide your heart</title>
-    <quantity>1</quantity>
-    <price>9.90</price>
-  </item>
+    <orderperson>John Smith</orderperson>
+    <shipto>
+        <name>Ola Nordmann</name>
+        <address>Langgt 23</address>
+        <city>4000 Stavanger</city>
+        <country>Norway</country>
+    </shipto>
+    <item>
+        <title>Empire Burlesque</title>
+        <note>Special Edition</note>
+        <quantity>1</quantity>
+        <price>10.90</price>
+    </item>
+    <item>
+        <title>Hide your heart</title>
+        <quantity>1</quantity>
+        <price>9.90</price>
+    </item>
 </shiporder>

--- a/xill-processor/src/test/resources/testresources/xml/xsdValidation.xsd
+++ b/xill-processor/src/test/resources/testresources/xml/xsdValidation.xsd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<!-- definition of simple elements -->
+<xs:element name="orderperson" type="xs:string"/>
+<xs:element name="name" type="xs:string"/>
+<xs:element name="address" type="xs:string"/>
+<xs:element name="city" type="xs:string"/>
+<xs:element name="country" type="xs:string"/>
+<xs:element name="title" type="xs:string"/>
+<xs:element name="note" type="xs:string"/>
+<xs:element name="quantity" type="xs:positiveInteger"/>
+<xs:element name="price" type="xs:decimal"/>
+
+<!-- definition of attributes -->
+<xs:attribute name="orderid" type="xs:string"/>
+
+<!-- definition of complex elements -->
+<xs:element name="shipto">
+  <xs:complexType>
+    <xs:sequence>
+      <xs:element ref="name"/>
+      <xs:element ref="address"/>
+      <xs:element ref="city"/>
+      <xs:element ref="country"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="item">
+  <xs:complexType>
+    <xs:sequence>
+      <xs:element ref="title"/>
+      <xs:element ref="note" minOccurs="0"/>
+      <xs:element ref="quantity"/>
+      <xs:element ref="price"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="shiporder">
+  <xs:complexType>
+    <xs:sequence>
+      <xs:element ref="orderperson"/>
+      <xs:element ref="shipto"/>
+      <xs:element ref="item" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute ref="orderid" use="required"/>
+  </xs:complexType>
+</xs:element>
+
+</xs:schema>

--- a/xill-processor/src/test/resources/testresources/xml/xsdValidation.xsd
+++ b/xill-processor/src/test/resources/testresources/xml/xsdValidation.xsd
@@ -1,52 +1,52 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-<!-- definition of simple elements -->
-<xs:element name="orderperson" type="xs:string"/>
-<xs:element name="name" type="xs:string"/>
-<xs:element name="address" type="xs:string"/>
-<xs:element name="city" type="xs:string"/>
-<xs:element name="country" type="xs:string"/>
-<xs:element name="title" type="xs:string"/>
-<xs:element name="note" type="xs:string"/>
-<xs:element name="quantity" type="xs:positiveInteger"/>
-<xs:element name="price" type="xs:decimal"/>
+    <!-- definition of simple elements -->
+    <xs:element name="orderperson" type="xs:string"/>
+    <xs:element name="name" type="xs:string"/>
+    <xs:element name="address" type="xs:string"/>
+    <xs:element name="city" type="xs:string"/>
+    <xs:element name="country" type="xs:string"/>
+    <xs:element name="title" type="xs:string"/>
+    <xs:element name="note" type="xs:string"/>
+    <xs:element name="quantity" type="xs:positiveInteger"/>
+    <xs:element name="price" type="xs:decimal"/>
 
-<!-- definition of attributes -->
-<xs:attribute name="orderid" type="xs:string"/>
+    <!-- definition of attributes -->
+    <xs:attribute name="orderid" type="xs:string"/>
 
-<!-- definition of complex elements -->
-<xs:element name="shipto">
-  <xs:complexType>
-    <xs:sequence>
-      <xs:element ref="name"/>
-      <xs:element ref="address"/>
-      <xs:element ref="city"/>
-      <xs:element ref="country"/>
-    </xs:sequence>
-  </xs:complexType>
-</xs:element>
+    <!-- definition of complex elements -->
+    <xs:element name="shipto">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="name"/>
+                <xs:element ref="address"/>
+                <xs:element ref="city"/>
+                <xs:element ref="country"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
 
-<xs:element name="item">
-  <xs:complexType>
-    <xs:sequence>
-      <xs:element ref="title"/>
-      <xs:element ref="note" minOccurs="0"/>
-      <xs:element ref="quantity"/>
-      <xs:element ref="price"/>
-    </xs:sequence>
-  </xs:complexType>
-</xs:element>
+    <xs:element name="item">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="title"/>
+                <xs:element ref="note" minOccurs="0"/>
+                <xs:element ref="quantity"/>
+                <xs:element ref="price"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
 
-<xs:element name="shiporder">
-  <xs:complexType>
-    <xs:sequence>
-      <xs:element ref="orderperson"/>
-      <xs:element ref="shipto"/>
-      <xs:element ref="item" maxOccurs="unbounded"/>
-    </xs:sequence>
-    <xs:attribute ref="orderid" use="required"/>
-  </xs:complexType>
-</xs:element>
+    <xs:element name="shiporder">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="orderperson"/>
+                <xs:element ref="shipto"/>
+                <xs:element ref="item" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute ref="orderid" use="required"/>
+        </xs:complexType>
+    </xs:element>
 
 </xs:schema>

--- a/xill-processor/src/test/resources/tests/xml/xsdCheckTest.xill
+++ b/xill-processor/src/test/resources/tests/xml/xsdCheckTest.xill
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2014 Xillio (support@xillio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Tests that the xsd validator validates the proivided XML file with the given XSD
+ */
+use XML, System, File, Assert;
+
+var xmlFile = "testresources/xml/xsdValidation.xml";
+var xsdFile = "testresources/xml/xsdValidation.xsd";
+
+Assert.isTrue(File.exists(xmlFile), "Cannot find XML file for testing");
+Assert.isTrue(File.exists(xsdFile), "Cannot find XSD file for testing");
+
+Assert.isTrue(XML.xsdCheck(xmlFile, xsdFile), "XML should be valid against the XSD");

--- a/xillio-parent/pom.xml
+++ b/xillio-parent/pom.xml
@@ -71,7 +71,7 @@
         <docgen.version>3.1.3</docgen.version>
         <jasypt.version>1.9.1</jasypt.version>
         <slf4j.version>1.7.21</slf4j.version>
-        <saxon.version>9.6.0-5</saxon.version>
+        <saxon.version>9.8.0-14</saxon.version>
         <sqlite.verion>3.8.11.2</sqlite.verion>
         <oracle.version>12.1.0.1.0</oracle.version>
         <jtds.version>1.3.1</jtds.version>


### PR DESCRIPTION
# Contents

* upgraded Saxon to a current version
* now the XSD validator gets passes String paths instead of Path.
* added a xill test for the validator
