### PR TITLE
Hotfix loading crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Xill Platform - Change Log
 All notable changes to this project will be documented in this file.
 
+## [next] - date
+
+### Fix
+
+* Fix a bug where starting with a corrupted settings file would result in an immediate crash
+
 ## [3.6.11] - 2018-08-09
 
 ### Add

--- a/xill-ide/src/main/java/nl/xillio/migrationtool/dialogs/FXMLDialog.java
+++ b/xill-ide/src/main/java/nl/xillio/migrationtool/dialogs/FXMLDialog.java
@@ -46,7 +46,8 @@ public class FXMLDialog extends Stage {
     public FXMLDialog(final String url) {
         loadFXML(getClass().getResource(url));
         initModality(Modality.APPLICATION_MODAL);
-        initOwner(Application.getPrimaryStage().getScene().getWindow());
+        Scene scene = Application.getPrimaryStage().getScene();
+        initOwner(scene == null ? null : scene.getWindow());
 
         try (InputStream image = this.getClass().getResourceAsStream("/icon.png")) {
             if (image != null) {


### PR DESCRIPTION
The warning dialog that was supposed to pop up when having a corrupted settings file now doesn't crash the application.

Two files are modified:
 - FXMLDialog.java contains the fix
 - SettingsHandler.java contains a minor codebase improvement, and a general format cleanup