### PR TITLE
Fix startup issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Xill Platform - Change Log
 All notable changes to this project will be documented in this file.
 
-## [next] - next
+## [3.6.14] - 2018-09-21
+
+### Change
+
+* Remove java version warning at startup
+
+### Fix
+
+* Lock version of eclipse-codegen to prevent security bugs which crash newly opened tab
 
 ## [3.6.13] - 2018-09-06
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,6 +65,7 @@ pipeline {
                     steps {
                         script {
                             configFileProvider([configFile(fileId: 'xill-platform/settings.xml', variable: 'MAVEN_SETTINGS')]) {
+                                sh "mvn clean"
                                 if (isRelease()) {
                                     sh createBintrayVersion()
                                     sh "mvn " +
@@ -100,6 +101,7 @@ pipeline {
                     }
                     steps {
                         configFileProvider([configFile(fileId: 'xill-platform/settings.xml', variable: 'MAVEN_SETTINGS')]) {
+                            bat "mvn clean"
                             bat "mvn " +
                                     "-P build-native " +
                                     "-s ${MAVEN_SETTINGS} " +

--- a/xillio-parent/pom.xml
+++ b/xillio-parent/pom.xml
@@ -94,6 +94,7 @@
         <maven.version>3.3.9</maven.version>
         <maven.plugin.tools.version>3.5</maven.plugin.tools.version>
         <mongo-java-driver.version>3.6.1</mongo-java-driver.version>
+        <eclipse-codegen.version>2.11.0-v20150806-0404</eclipse-codegen.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -105,6 +106,10 @@
             <url>https://jcenter.bintray.com</url>
         </repository>
         <repository>
+            <id>xillio-oss</id>
+            <url>https://maven.xillio.com/artifactory/oss-libs-release/</url>
+        </repository>
+        <repository>
             <id>xillio-third-party</id>
             <url>https://maven.xillio.com/artifactory/libs-third-party</url>
             <releases>
@@ -113,6 +118,18 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+        </repository>
+        <repository>
+            <id>xillio-releases</id>
+            <url>https://maven.xillio.com/artifactory/libs-release</url>
+        </repository>
+        <repository>
+            <id>xillio-snapshots</id>
+            <url>https://maven.xillio.com/artifactory/libs-snapshot</url>
+        </repository>
+        <repository>
+            <id>xillio-remote</id>
+            <url>https://maven.xillio.com/artifactory/remote-release</url>
         </repository>
     </repositories>
 
@@ -370,6 +387,11 @@
                 <groupId>org.mongodb</groupId>
                 <artifactId>mongo-java-driver</artifactId>
                 <version>${mongo-java-driver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.emf</groupId>
+                <artifactId>org.eclipse.emf.codegen</artifactId>
+                <version>${eclipse-codegen.version}</version>
             </dependency>
             <!-- Internal Project Dependencies -->
             <dependency>


### PR DESCRIPTION
The current build does not allow you to open a new tab. This PR fixes that by locking the version of eclipse codegen.

I also removed the java version warning at startup since we now allow mac and linux developers to manually install java.