### PR TITLE
Issue 34 phantom js pool fully used

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (C) 2014 Xillio (support@xillio.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 def createBintrayVersion() {
     return "curl -fsS " +
             "-u '${env.BINTRAY_USR}:${env.BINTRAY_PSW}' " +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [next] - next
 
+## [3.6.20] - 2019-04-08
+
+### Fix
+
+* Web plugin will no longer run out of entities because of Windows errors.
+
 ## [3.6.19] - 2019-02-21
 
 ### Fix

--- a/plugin-web/src/main/java/nl/xillio/xill/plugins/web/data/PhantomJSPool.java
+++ b/plugin-web/src/main/java/nl/xillio/xill/plugins/web/data/PhantomJSPool.java
@@ -142,10 +142,11 @@ public class PhantomJSPool implements AutoCloseable {
             try {
                 instance.dispose();
             } catch (UnreachableBrowserException e) {
-                LOGGER.error("Could not reach the instance. The instance will now be dropped without shuting down.");
-                instance.close();
+                LOGGER.error("Could not reach the instance. The instance will now be dropped without shutting down.");
             } catch (Exception e) {
                 LOGGER.error("Error when closing PhantomJS instances! " + e.getMessage(), e);
+            } finally {
+                instance.close();
             }
         }
         poolEntities.clear();

--- a/plugin-web/src/main/java/nl/xillio/xill/plugins/web/data/PhantomJSPool.java
+++ b/plugin-web/src/main/java/nl/xillio/xill/plugins/web/data/PhantomJSPool.java
@@ -21,6 +21,7 @@ import me.biesaart.utils.Log;
 import nl.xillio.xill.api.XillThreadFactory;
 import nl.xillio.xill.api.data.MetadataExpression;
 import nl.xillio.xill.plugins.web.services.web.WebService;
+import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -137,12 +138,17 @@ public class PhantomJSPool implements AutoCloseable {
      * processes in the pool will be terminated)
      */
     public void close() {
-        try {
-            poolEntities.forEach(PhantomJSPool.Entity::dispose);
-            poolEntities.clear();
-        } catch (Exception e) {
-            LOGGER.error("Error when closing PhantomJS instances! " + e.getMessage(), e);
+        for (Entity instance : poolEntities) {
+            try {
+                instance.dispose();
+            } catch (UnreachableBrowserException e) {
+                LOGGER.error("Could not reach the instance. The instance will now be dropped without shuting down.");
+                instance.close();
+            } catch (Exception e) {
+                LOGGER.error("Error when closing PhantomJS instances! " + e.getMessage(), e);
+            }
         }
+        poolEntities.clear();
     }
 
     /**

--- a/plugin-web/src/main/java/nl/xillio/xill/plugins/web/services/web/WebServiceImpl.java
+++ b/plugin-web/src/main/java/nl/xillio/xill/plugins/web/services/web/WebServiceImpl.java
@@ -35,6 +35,9 @@ import org.apache.http.ssl.SSLContexts;
 import org.openqa.selenium.*;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
+import org.openqa.selenium.remote.UnreachableBrowserException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
@@ -51,11 +54,14 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+
 /**
  * The implementation of the {@link WebService} interface.
  */
 @Singleton
 public class WebServiceImpl implements WebService {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(WebServiceImpl.class);
 
     @Override
     public void click(final WebVariable node) {
@@ -355,7 +361,15 @@ public class WebServiceImpl implements WebService {
 
     @Override
     public PhantomJSPool.Entity getEntityFromPool(final PhantomJSPool pool, final Options options) {
-        PhantomJSPool.Entity pjsInstance = pool.get(pool.createIdentifier(options), this);
+        PhantomJSPool.Entity pjsInstance = null;
+
+        try {
+            pjsInstance = pool.get(pool.createIdentifier(options), this);
+        } catch (UnreachableBrowserException e) {
+            pool.close();
+            pjsInstance = pool.get(pool.createIdentifier(options), this);
+        }
+
         if (pjsInstance == null) {
             throw new OperationFailedException("get PhantomJS Entity.", "PhantomJS pool is fully used and cannot provide another instance!");
         }
@@ -381,7 +395,7 @@ public class WebServiceImpl implements WebService {
         try {
             Files.createDirectories(targetFilePath.getParent());
         } catch (IOException e) {
-            throw new OperationFailedException("copy file to target location", "Was unable to create new folder in path: " + targetFilePath.getParent().toAbsolutePath() + ".", "Check if the supplied path is correct.",e);
+            throw new OperationFailedException("copy file to target location", "Was unable to create new folder in path: " + targetFilePath.getParent().toAbsolutePath() + ".", "Check if the supplied path is correct.", e);
         }
         Files.copy(stream, targetFilePath, StandardCopyOption.REPLACE_EXISTING);
     }

--- a/plugin-web/src/main/java/nl/xillio/xill/plugins/web/services/web/WebServiceImpl.java
+++ b/plugin-web/src/main/java/nl/xillio/xill/plugins/web/services/web/WebServiceImpl.java
@@ -361,17 +361,21 @@ public class WebServiceImpl implements WebService {
 
     @Override
     public PhantomJSPool.Entity getEntityFromPool(final PhantomJSPool pool, final Options options) {
-        PhantomJSPool.Entity pjsInstance = null;
+        PhantomJSPool.Entity pjsInstance = getEntity(pool, options);
 
+        if (pjsInstance == null) {
+            throw new OperationFailedException("get PhantomJS Entity.", "PhantomJS pool is fully used and cannot provide another instance!");
+        }
+        return pjsInstance;
+    }
+
+    private PhantomJSPool.Entity getEntity(PhantomJSPool pool, Options options) {
+        PhantomJSPool.Entity pjsInstance;
         try {
             pjsInstance = pool.get(pool.createIdentifier(options), this);
         } catch (UnreachableBrowserException e) {
             pool.close();
             pjsInstance = pool.get(pool.createIdentifier(options), this);
-        }
-
-        if (pjsInstance == null) {
-            throw new OperationFailedException("get PhantomJS Entity.", "PhantomJS pool is fully used and cannot provide another instance!");
         }
         return pjsInstance;
     }

--- a/plugin-web/src/test/java/nl/xillio/xill/plugins/web/services/web/WebServiceImplTest.java
+++ b/plugin-web/src/test/java/nl/xillio/xill/plugins/web/services/web/WebServiceImplTest.java
@@ -982,8 +982,12 @@ public class WebServiceImplTest {
         implementation.download(url, file, null, 1000);
     }
 
+    /**
+     * Test that the PhantomJSPool is closed if one of the Instances crashes.
+     * @throws Exception
+     */
     @Test(expectedExceptions = UnreachableBrowserException.class)
-    public void testPoolNotFillingUp() throws Exception {
+    public void testPoolCloseOnCrash() throws Exception {
         WebServiceImpl implementation = spy(new WebServiceImpl());
 
         PhantomJSPool pool = mock(PhantomJSPool.class);

--- a/plugin-web/src/test/java/nl/xillio/xill/plugins/web/services/web/WebServiceImplTest.java
+++ b/plugin-web/src/test/java/nl/xillio/xill/plugins/web/services/web/WebServiceImplTest.java
@@ -34,6 +34,7 @@ import org.openqa.selenium.WebDriver.TargetLocator;
 import org.openqa.selenium.WebDriver.Timeouts;
 import org.openqa.selenium.WebDriver.Window;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
+import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -979,6 +980,21 @@ public class WebServiceImplTest {
 
         // run
         implementation.download(url, file, null, 1000);
+    }
+
+    @Test(expectedExceptions = UnreachableBrowserException.class)
+    public void testPoolNotFillingUp() throws Exception {
+        WebServiceImpl implementation = spy(new WebServiceImpl());
+
+        PhantomJSPool pool = mock(PhantomJSPool.class);
+
+        when(pool.createIdentifier(any())).thenReturn(null);
+        when(pool.get(any(), any())).thenThrow(new UnreachableBrowserException("test"));
+
+        implementation.getEntityFromPool(pool, null);
+
+        verify(pool, times(1)).close();
+
     }
 
     /**


### PR DESCRIPTION
This fixes the PhantomJSPool from filling up because of windows access errors. Now whenever such an error is encountered the entire pool is closed.

###### Author:

- [x] No IntelliJ warnings on new code (including spelling)
- [x] No bugs/vulnerabilities on [sonar](https://sonarcloud.io/dashboard?branch=Issue-34-PhantomJS-pool-fully-used&id=nl.xillio.xill%3Axill-build)
- [x] High line coverage on new code (any higher would need a rewrite)
- [x] Tests cover all (reasonable) edge cases
- [x] Reformat code doesn't leave any file modified

###### Reviewers:

- [X] All _Creator_ checkboxes are rightfully checked
- [ ] The code is clearly structured (no large methods, clear naming, good separation of concerns, etc.)
- [ ] The code has enough helpful documentation and comments
- [ ] The implementation conforms to the issue description
- [ ] [Do's and don'ts](https://help.xillio.com/conventions/java-code/) are observed 