### PR TITLE
Update Jackson version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,7 +39,13 @@ def isRelease() {
 }
 
 pipeline {
-    agent none
+    agent {
+        dockerfile {
+            dir 'buildagent'
+            label 'docker'
+            args '-u 0:0'
+        }
+    }
     parameters {
         booleanParam(name: 'NO_SONAR', defaultValue: false, description: 'Skip sonar analysis')
         booleanParam(name: 'PUBLISH_BUILD', defaultValue: false, description: 'Publish this build to bintray')
@@ -51,13 +57,6 @@ pipeline {
         stage('Build') {
             parallel {
                 stage('Linux') {
-                    agent {
-                        dockerfile {
-                            dir 'buildagent'
-                            label 'docker'
-                            args '-u 0:0'
-                        }
-                    }
                     environment {
                         MAVEN_VERSION = readMavenPom().getVersion()
                     }
@@ -124,13 +123,6 @@ pipeline {
         }
 
         stage('Sonar Analysis') {
-            agent {
-                dockerfile {
-                    dir 'buildagent'
-                    label 'docker'
-                    args '-u 0:0'
-                }
-            }
             when {
                 expression {
                     !params.NO_SONAR

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -57,14 +57,6 @@ pipeline {
         stage('Build') {
             parallel {
                 stage('Linux') {
-                    agent {
-                        dockerfile {
-                            dir 'buildagent'
-                            label 'docker'
-                            args '-u 0:0'
-                            reuseNode true
-                        }
-                    }
                     environment {
                         MAVEN_VERSION = readMavenPom().getVersion()
                     }
@@ -98,32 +90,31 @@ pipeline {
                         }
                     }
                 }
-                stage('Windows') {
-                    agent {
-                        label 'windows && xill-platform'
-                    }
-                    environment {
-                        MAVEN_VERSION = readMavenPom().getVersion()
-                    }
-                    steps {
-                        configFileProvider([configFile(fileId: '913ac216-d52d-41b0-94f9-cc51e28bd431', variable: 'MAVEN_SETTINGS')]) {
-                            bat "mvn clean -P build-native"
-                            bat "mvn " +
-                                    "-P build-native " +
-                                    "-s ${MAVEN_SETTINGS} " +
-                                    "-B  " +
-                                    "verify " +
-                                    "--fail-at-end"
+                node('windows && xill-platform') {
+                    stage('Windows') {
+                        environment {
+                            MAVEN_VERSION = readMavenPom().getVersion()
                         }
-                        script {
-                            if (isRelease()) {
-                                bat uploadFileToBintray("Xill-IDE", "xill-ide-native/target/xill-ide-${env.MAVEN_VERSION}-win.zip", "xill-ide-${env.MAVEN_VERSION}-win.zip")
+                        steps {
+                            configFileProvider([configFile(fileId: '913ac216-d52d-41b0-94f9-cc51e28bd431', variable: 'MAVEN_SETTINGS')]) {
+                                bat "mvn clean -P build-native"
+                                bat "mvn " +
+                                        "-P build-native " +
+                                        "-s ${MAVEN_SETTINGS} " +
+                                        "-B  " +
+                                        "verify " +
+                                        "--fail-at-end"
+                            }
+                            script {
+                                if (isRelease()) {
+                                    bat uploadFileToBintray("Xill-IDE", "xill-ide-native/target/xill-ide-${env.MAVEN_VERSION}-win.zip", "xill-ide-${env.MAVEN_VERSION}-win.zip")
+                                }
                             }
                         }
-                    }
-                    post {
-                        always {
-                            junit allowEmptyResults: true, testResults: '**/target/*-reports/*.xml'
+                        post {
+                            always {
+                                junit allowEmptyResults: true, testResults: '**/target/*-reports/*.xml'
+                            }
                         }
                     }
                 }
@@ -131,14 +122,6 @@ pipeline {
         }
 
         stage('Sonar Analysis') {
-            agent {
-                dockerfile {
-                    dir 'buildagent'
-                    label 'docker'
-                    args '-u 0:0'
-                    reuseNode true
-                }
-            }
             when {
                 expression {
                     !params.NO_SONAR

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -57,6 +57,14 @@ pipeline {
         stage('Build') {
             parallel {
                 stage('Linux') {
+                    agent {
+                        dockerfile {
+                            dir 'buildagent'
+                            label 'docker'
+                            args '-u 0:0'
+                            reuseNode true
+                        }
+                    }
                     environment {
                         MAVEN_VERSION = readMavenPom().getVersion()
                     }
@@ -123,6 +131,14 @@ pipeline {
         }
 
         stage('Sonar Analysis') {
+            agent {
+                dockerfile {
+                    dir 'buildagent'
+                    label 'docker'
+                    args '-u 0:0'
+                    reuseNode true
+                }
+            }
             when {
                 expression {
                     !params.NO_SONAR

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -90,31 +90,32 @@ pipeline {
                         }
                     }
                 }
-                node('windows && xill-platform') {
-                    stage('Windows') {
-                        environment {
-                            MAVEN_VERSION = readMavenPom().getVersion()
+                stage('Windows') {
+                    agent {
+                        node('windows && xill-platform')
+                    }
+                    environment {
+                        MAVEN_VERSION = readMavenPom().getVersion()
+                    }
+                    steps {
+                        configFileProvider([configFile(fileId: '913ac216-d52d-41b0-94f9-cc51e28bd431', variable: 'MAVEN_SETTINGS')]) {
+                            bat "mvn clean -P build-native"
+                            bat "mvn " +
+                                    "-P build-native " +
+                                    "-s ${MAVEN_SETTINGS} " +
+                                    "-B  " +
+                                    "verify " +
+                                    "--fail-at-end"
                         }
-                        steps {
-                            configFileProvider([configFile(fileId: '913ac216-d52d-41b0-94f9-cc51e28bd431', variable: 'MAVEN_SETTINGS')]) {
-                                bat "mvn clean -P build-native"
-                                bat "mvn " +
-                                        "-P build-native " +
-                                        "-s ${MAVEN_SETTINGS} " +
-                                        "-B  " +
-                                        "verify " +
-                                        "--fail-at-end"
-                            }
-                            script {
-                                if (isRelease()) {
-                                    bat uploadFileToBintray("Xill-IDE", "xill-ide-native/target/xill-ide-${env.MAVEN_VERSION}-win.zip", "xill-ide-${env.MAVEN_VERSION}-win.zip")
-                                }
+                        script {
+                            if (isRelease()) {
+                                bat uploadFileToBintray("Xill-IDE", "xill-ide-native/target/xill-ide-${env.MAVEN_VERSION}-win.zip", "xill-ide-${env.MAVEN_VERSION}-win.zip")
                             }
                         }
-                        post {
-                            always {
-                                junit allowEmptyResults: true, testResults: '**/target/*-reports/*.xml'
-                            }
+                    }
+                    post {
+                        always {
+                            junit allowEmptyResults: true, testResults: '**/target/*-reports/*.xml'
                         }
                     }
                 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,13 +39,7 @@ def isRelease() {
 }
 
 pipeline {
-    agent {
-        dockerfile {
-            dir 'buildagent'
-            label 'docker'
-            args '-u 0:0'
-        }
-    }
+    agent none
     parameters {
         booleanParam(name: 'NO_SONAR', defaultValue: false, description: 'Skip sonar analysis')
         booleanParam(name: 'PUBLISH_BUILD', defaultValue: false, description: 'Publish this build to bintray')
@@ -57,8 +51,16 @@ pipeline {
         stage('Build') {
             parallel {
                 stage('Linux') {
+                    agent {
+                        dockerfile {
+                            dir 'buildagent'
+                            label 'docker'
+                            args '-u 0:0'
+                        }
+                    }
                     environment {
                         MAVEN_VERSION = readMavenPom().getVersion()
+                        SONARCLOUD_LOGIN = credentials('aaf177ed-92f7-4dd7-a482-b6b407be60ae')
                     }
                     steps {
                         script {
@@ -80,6 +82,16 @@ pipeline {
                                             "-B  " +
                                             "verify " +
                                             "--fail-at-end"
+                                }
+                            }
+                        }
+                        script {
+                            if (!params.NO_SONAR) {
+                                configFileProvider([configFile(fileId: '913ac216-d52d-41b0-94f9-cc51e28bd431', variable: 'MAVEN_SETTINGS')]) {
+                                    sh 'mvn -s "$MAVEN_SETTINGS" -B ' +
+                                            "-Dsonar.login='${env.SONARCLOUD_LOGIN}' " +
+                                            "-Dsonar.branch.name='${env.GIT_BRANCH}' " +
+                                            'sonar:sonar'
                                 }
                             }
                         }
@@ -118,25 +130,6 @@ pipeline {
                             junit allowEmptyResults: true, testResults: '**/target/*-reports/*.xml'
                         }
                     }
-                }
-            }
-        }
-
-        stage('Sonar Analysis') {
-            when {
-                expression {
-                    !params.NO_SONAR
-                }
-            }
-            environment {
-                SONARCLOUD_LOGIN = credentials('aaf177ed-92f7-4dd7-a482-b6b407be60ae')
-            }
-            steps {
-                configFileProvider([configFile(fileId: '913ac216-d52d-41b0-94f9-cc51e28bd431', variable: 'MAVEN_SETTINGS')]) {
-                    sh 'mvn -s "$MAVEN_SETTINGS" -B ' +
-                            "-Dsonar.login='${env.SONARCLOUD_LOGIN}' " +
-                            "-Dsonar.branch.name='${env.GIT_BRANCH}' " +
-                            'sonar:sonar'
                 }
             }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -104,7 +104,7 @@ pipeline {
                 }
                 stage('Windows') {
                     agent {
-                        node('windows && xill-platform')
+                        label 'windows && xill-platform'
                     }
                     environment {
                         MAVEN_VERSION = readMavenPom().getVersion()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Xill Platform - Change Log
 All notable changes to this project will be documented in this file.
 
-## [next] - next
+## [3.6.21] - 2019-05-24
+
+### Fix
+
+* Update version of Jackson library
 
 ## [3.6.20] - 2019-04-08
 

--- a/buildagent/Dockerfile
+++ b/buildagent/Dockerfile
@@ -14,17 +14,11 @@
 # limitations under the License.
 #
 
-FROM ubuntu:bionic
+FROM openjdk:8
 
 # Install Dependencies
 RUN apt-get update && apt-get install -y software-properties-common debconf-utils git maven curl build-essential \
-    chrpath libssl-dev libxft-dev libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev openjdk-8-jdk openjfx
-
-# Set the locale
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+    chrpath libssl-dev libxft-dev libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev openjfx
 
 # Set timezone
 ENV DEBIAN_FRONTEND=noninteractive

--- a/buildagent/Dockerfile
+++ b/buildagent/Dockerfile
@@ -18,13 +18,7 @@ FROM ubuntu:bionic
 
 # Install Dependencies
 RUN apt-get update && apt-get install -y software-properties-common debconf-utils git maven curl build-essential \
-    chrpath libssl-dev libxft-dev libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev
-
-# Accept Oracle TOS
-RUN echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
-
-# Install Oracle JDK 8
-RUN add-apt-repository ppa:webupd8team/java && apt-get update && apt-get install -y oracle-java8-installer
+    chrpath libssl-dev libxft-dev libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev openjdk-8-jdk openjfx
 
 # Set the locale
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen

--- a/buildagent/Dockerfile
+++ b/buildagent/Dockerfile
@@ -27,4 +27,3 @@ RUN apt-get install -y tzdata && ln -fs /usr/share/zoneinfo/Europe/Amsterdam /et
 
 # Install Docker
 RUN curl -sSL get.docker.com | bash
-

--- a/xill-api/pom.xml
+++ b/xill-api/pom.xml
@@ -44,10 +44,6 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>

--- a/xillio-parent/pom.xml
+++ b/xillio-parent/pom.xml
@@ -64,7 +64,7 @@
         <commons.version>1.5.0</commons.version>
         <commons.cli.version>1.4</commons.cli.version>
         <guice.version>4.0</guice.version>
-        <jackson.version>2.8.11</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
         <guava.version>18.0</guava.version>
         <poi.version>3.13</poi.version>
         <log4j.version>2.8.2</log4j.version>

--- a/xillio-parent/pom.xml
+++ b/xillio-parent/pom.xml
@@ -80,6 +80,7 @@
         <elasticsearch.version>1.6.0</elasticsearch.version>
         <selenium.version>2.45.0</selenium.version>
         <phantomjs.version>1.2.1</phantomjs.version>
+        <mariadb-java-client.version>2.4.1</mariadb-java-client.version>
         <phantomjs.binary.version>2.1.1</phantomjs.binary.version>
         <httpclient.version>4.5.1</httpclient.version>
         <jsoup.version>1.8.3</jsoup.version>
@@ -135,14 +136,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <!-- Import dependency management from Spring Boot -->
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>1.4.1.RELEASE</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
@@ -265,18 +258,7 @@
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <!-- Force version of jackson-annotations as <2.9.0 does not compile with jackson-bom >2.9.0-->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
@@ -398,6 +380,11 @@
                 <groupId>org.eclipse.emf</groupId>
                 <artifactId>org.eclipse.emf.codegen</artifactId>
                 <version>${eclipse-codegen.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mariadb.jdbc</groupId>
+                <artifactId>mariadb-java-client</artifactId>
+                <version>${mariadb-java-client.version}</version>
             </dependency>
             <!-- Internal Project Dependencies -->
             <dependency>

--- a/xillio-parent/pom.xml
+++ b/xillio-parent/pom.xml
@@ -273,6 +273,12 @@
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
+            <!-- Force version of jackson-annotations as <2.9.0 does not compile with jackson-bom >2.9.0-->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>


### PR DESCRIPTION
All Jackson versions from 2.0.0 up until 2.9.9 contain a security vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2019-12086

This PR will update Jackson to the latest version. I also had to force the `jackson-annotations` package to the same version as one of our dependencies (probably Spring Boot) puts that package with a version below 2.9.0 in the classPath which does not compile anymore with Jackson 2.9.9. See reported [GitHub issues](https://github.com/FasterXML/jackson-databind/issues/1545) and related issues.