### PR TITLE
Update jackson version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,19 +15,19 @@
  */
 def createBintrayVersion() {
     return "curl " +
-            "-u '${env.BINTRAY_USR}:${env.BINTRAY_PSW}' " +
+            "-u ':${env.BINTRAY_PSW}' " +
             "-X POST https://api.bintray.com/packages/xillio/Xill-Platform/Xill-CLI/versions " +
             "-H 'Content-Type: application/json' " +
             "-d '{\"name\": \"${env.MAVEN_VERSION}\"}' && " +
             "curl " +
-            "-u '${env.BINTRAY_USR}:${env.BINTRAY_PSW}' " +
+            "-u ':${env.BINTRAY_PSW}' " +
             "-X POST https://api.bintray.com/packages/xillio/Xill-Platform/Xill-IDE/versions " +
             "-H 'Content-Type: application/json' " +
             "-d '{\"name\": \"${env.MAVEN_VERSION}\"}'"
 }
 
 def uploadFileToBintray(String packageName, String file, String fileName) {
-    return "curl -u \"${env.BINTRAY_USR}:${env.BINTRAY_PSW}\" " +
+    return "curl -u \":${env.BINTRAY_PSW}\" " +
             "-X PUT " +
             "https://api.bintray.com/content/xillio/Xill-Platform/${packageName}/${env.MAVEN_VERSION}/${fileName}?publish=1 " +
             "-H \"Content-Type: application/json\" " +

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 def createBintrayVersion() {
-    return "curl -fsS " +
+    return "curl " +
             "-u '${env.BINTRAY_USR}:${env.BINTRAY_PSW}' " +
             "-X POST https://api.bintray.com/packages/xillio/Xill-Platform/Xill-CLI/versions " +
             "-H 'Content-Type: application/json' " +
             "-d '{\"name\": \"${env.MAVEN_VERSION}\"}' && " +
-            "curl -fsS " +
+            "curl " +
             "-u '${env.BINTRAY_USR}:${env.BINTRAY_PSW}' " +
             "-X POST https://api.bintray.com/packages/xillio/Xill-Platform/Xill-IDE/versions " +
             "-H 'Content-Type: application/json' " +
@@ -27,7 +27,7 @@ def createBintrayVersion() {
 }
 
 def uploadFileToBintray(String packageName, String file, String fileName) {
-    return "curl -fsS -u \"${env.BINTRAY_USR}:${env.BINTRAY_PSW}\" " +
+    return "curl -u \"${env.BINTRAY_USR}:${env.BINTRAY_PSW}\" " +
             "-X PUT " +
             "https://api.bintray.com/content/xillio/Xill-Platform/${packageName}/${env.MAVEN_VERSION}/${fileName}?publish=1 " +
             "-H \"Content-Type: application/json\" " +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Xill Platform - Change Log
 All notable changes to this project will be documented in this file.
 
+## [3.6.22] - 2019-07-23
+
+### Fix
+
+* Update version of Jackson library
+
 ## [3.6.21] - 2019-05-24
 
 ### Fix

--- a/xillio-parent/pom.xml
+++ b/xillio-parent/pom.xml
@@ -64,7 +64,7 @@
         <commons.version>1.5.0</commons.version>
         <commons.cli.version>1.4</commons.cli.version>
         <guice.version>4.0</guice.version>
-        <jackson.version>2.9.9</jackson.version>
+        <jackson.version>2.9.9.1</jackson.version>
         <guava.version>18.0</guava.version>
         <poi.version>3.13</poi.version>
         <log4j.version>2.8.2</log4j.version>


### PR DESCRIPTION
There is another security vulnerability in Jackson 2.9.9. Therefore, we have to upgrade to 2.9.9.1. I've also (hopefully) fixed the publish to Bintray as the authentication mechanisms of Bintray has changed. Omitting the username from the basic authentication works. I've also removed the `fsS` option from the curl commands to log the output of the command.