### PR TITLE
Fix sec vulnerabilities

### DIFF
--- a/plugin-exiftool/pom.xml
+++ b/plugin-exiftool/pom.xml
@@ -50,10 +50,10 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>http://www.sno.phy.queensu.ca/~phil/exiftool/exiftool-10.21.zip</url>
+                            <url>https://exiftool.org/exiftool-12.37.zip</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}/classes</outputDirectory>
-                            <md5>3fb9d87e560e9a3ba1352636f4e30931</md5>
+                            <md5>939eaf0906efab467b1d8ef4f545fd71</md5>
                         </configuration>
                     </execution>
                 </executions>

--- a/plugin-xurl/src/test/java/nl/xillio/xill/plugins/xurl/constructs/AbstractRequestConstructTest.java
+++ b/plugin-xurl/src/test/java/nl/xillio/xill/plugins/xurl/constructs/AbstractRequestConstructTest.java
@@ -76,7 +76,7 @@ public class AbstractRequestConstructTest extends TestUtils {
 
     @Test(expectedExceptions = RobotRuntimeException.class, expectedExceptionsMessageRegExp = ".*host.*")
     public void testExecuteHostConnectException() throws IOException {
-        construct.execute(executor(new HttpHostConnectException(new IOException(), new HttpHost(""))), null);
+        construct.execute(executor(new HttpHostConnectException(new IOException(), new HttpHost("https://fakeurl.com"))), null);
     }
 
     @Test(expectedExceptions = RobotRuntimeException.class, expectedExceptionsMessageRegExp = ".*failed.*")

--- a/xill-processor/src/test/java/nl/xillio/xill/plugins/string/constructs/WordDistanceConstructTest.java
+++ b/xill-processor/src/test/java/nl/xillio/xill/plugins/string/constructs/WordDistanceConstructTest.java
@@ -15,14 +15,12 @@
  */
 package nl.xillio.xill.plugins.string.constructs;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import nl.xillio.xill.TestUtils;
 import nl.xillio.xill.api.components.MetaExpression;
-import nl.xillio.xill.plugins.string.services.string.StringUtilityService;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 /**
  * Test the {@link RepeatConstruct}.

--- a/xill-processor/src/test/resources/tests/web/loadPage.xill
+++ b/xill-processor/src/test/resources/tests/web/loadPage.xill
@@ -19,6 +19,6 @@
 
 use System, Web, Assert;
 
-var page = Web.loadPage("https://www-eng-x.llnl.gov/documents/tests/txt.html");
+var page = Web.loadPage("https://phet-dev.colorado.edu/html/build-an-atom/0.0.0-4/simple-text-only-test-page.html");
 var title = Web.xPath(page,"//h1/text()");
-Assert.equal(title, "Plain Text Test");
+Assert.equal(title, "Simple Test Page");

--- a/xillio-parent/pom.xml
+++ b/xillio-parent/pom.xml
@@ -66,7 +66,7 @@
         <guice.version>4.0</guice.version>
         <jackson.version>2.9.10.8</jackson.version>
         <guava.version>18.0</guava.version>
-        <poi.version>3.13</poi.version>
+        <poi.version>3.17</poi.version>
         <log4j.version>2.16.0</log4j.version>
         <docgen.version>3.1.3</docgen.version>
         <jasypt.version>1.9.1</jasypt.version>
@@ -83,7 +83,7 @@
         <mariadb-java-client.version>2.4.1</mariadb-java-client.version>
         <phantomjs.binary.version>2.1.1</phantomjs.binary.version>
         <httpclient.version>4.5.1</httpclient.version>
-        <jsoup.version>1.8.3</jsoup.version>
+        <jsoup.version>1.14.2</jsoup.version>
         <mysql.version>6.0.2</mysql.version>
         <flapdoodle.version>1.50.5</flapdoodle.version>
         <asm.version>5.0.1</asm.version>

--- a/xillio-parent/pom.xml
+++ b/xillio-parent/pom.xml
@@ -67,7 +67,7 @@
         <jackson.version>2.9.9.1</jackson.version>
         <guava.version>18.0</guava.version>
         <poi.version>3.13</poi.version>
-        <log4j.version>2.8.2</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <docgen.version>3.1.3</docgen.version>
         <jasypt.version>1.9.1</jasypt.version>
         <slf4j.version>1.7.21</slf4j.version>

--- a/xillio-parent/pom.xml
+++ b/xillio-parent/pom.xml
@@ -64,7 +64,7 @@
         <commons.version>1.5.0</commons.version>
         <commons.cli.version>1.4</commons.cli.version>
         <guice.version>4.0</guice.version>
-        <jackson.version>2.9.9.1</jackson.version>
+        <jackson.version>2.9.10.8</jackson.version>
         <guava.version>18.0</guava.version>
         <poi.version>3.13</poi.version>
         <log4j.version>2.16.0</log4j.version>

--- a/xillio-parent/pom.xml
+++ b/xillio-parent/pom.xml
@@ -82,9 +82,9 @@
         <phantomjs.version>1.2.1</phantomjs.version>
         <mariadb-java-client.version>2.4.1</mariadb-java-client.version>
         <phantomjs.binary.version>2.1.1</phantomjs.binary.version>
-        <httpclient.version>4.5.1</httpclient.version>
+        <httpclient.version>4.5.13</httpclient.version>
         <jsoup.version>1.14.2</jsoup.version>
-        <mysql.version>6.0.2</mysql.version>
+        <mysql.version>8.0.16</mysql.version>
         <flapdoodle.version>1.50.5</flapdoodle.version>
         <asm.version>5.0.1</asm.version>
         <jgit.version>4.5.0.201609210915-r</jgit.version>


### PR DESCRIPTION
This is an ad hoc PR addressing the [log4j security issue](https://logging.apache.org/log4j/2.x/security.html).

I decided to expand the scope and also fix other of the security vulnerabilities alerted by dependabot, to be able to release all at once.